### PR TITLE
Change naming of variables in Waterfall solution

### DIFF
--- a/solution/README.md
+++ b/solution/README.md
@@ -45,15 +45,15 @@ function asyncTimesTen(x, callBack) {
   }, 200)
 }
 
-function waterfall(args, tasks, cb) {
+function waterfall(arg, tasks, cb) {
     if(tasks.length === 0){
-      return cb(null, args)
+      return cb(null, arg)
     }
-    tasks[0](args, function(err, arg){
+    tasks[0](arg, function(err, newArg){
         if (err){
           return cb(err)
         }
-        return waterfall(arg, tasks.slice(1), cb) 
+        return waterfall(newArg, tasks.slice(1), cb) 
     });
 }
 


### PR DESCRIPTION
In the Waterfall fx solution README.md I have changed these variables so they are consistent with the challenge's README.md:

In the challenge the fx parameters are written like this:  `function waterfall(arg, tasks, cb) {`
In the solution the fx parameters are written like this:  `function waterfall(args, tasks, cb) {`

I think this is unnecessarily confusing to changeup var names so modifying the solution:

args -> arg;
arg-> newArg;